### PR TITLE
delete: use destroy pod to kill vm

### DIFF
--- a/src/oci.c
+++ b/src/oci.c
@@ -1190,12 +1190,13 @@ gboolean
 cc_oci_stop (struct cc_oci_config *config,
 		struct oci_state *state)
 {
-	g_assert (config);
-	g_assert (state);
+	if (! (config && state)){
+		return false;
+	}
 
 	if (cc_oci_vm_running (state)) {
 		gboolean ret;
-		ret = cc_oci_vm_shutdown (state->comms_path, state->vm->pid);
+		ret = cc_proxy_hyper_destroy_pod(config);
 		if (! ret) {
 			return false;
 		}


### PR DESCRIPTION
This patch fix a hang if delete command is done
using cc-agent.target, this target does not depend
on systemd-logind and shutdown is not handled.

Lets use destroypod command to shutdown the vm.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>